### PR TITLE
Log fix

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -267,8 +267,6 @@ func init() {
 	gConf.LogLevel = int(LvINFO)
 	gConf.Network.ShareBandwidth = 10
 	gConf.Network.ServerHost = "api.openp2p.cn"
-	gConf.Network.ServerPort = WsPort
-
 }
 
 func (c *Config) load() error {
@@ -380,7 +378,7 @@ type NetworkConfig struct {
 
 func parseParams(subCommand string, cmd string) {
 	fset := flag.NewFlagSet(subCommand, flag.ExitOnError)
-	serverHost := fset.String("serverhost", "api.openp2p.cn", "server host ")
+	serverHost := fset.String("serverhost", gConf.Network.ServerHost, "server host ")
 	serverPort := fset.Int("serverport", WsPort, "server port ")
 	// serverHost := flag.String("serverhost", "127.0.0.1", "server host ") // for debug
 	token := fset.Uint64("token", 0, "token")
@@ -396,11 +394,11 @@ func parseParams(subCommand string, cmd string) {
 	punchPriority := fset.Int("punch_priority", 0, "bitwise DisableTCP|DisableUDP|UDPFirst  0:tcp and udp both enable, tcp first")
 	appName := fset.String("appname", "", "app name")
 	relayNode := fset.String("relaynode", "", "relaynode")
-	shareBandwidth := fset.Int("sharebandwidth", 10, "N mbps share bandwidth limit, private network no limit")
+	shareBandwidth := fset.Int("sharebandwidth", gConf.Network.ShareBandwidth, "N mbps share bandwidth limit, private network no limit")
 	daemonMode := fset.Bool("d", false, "daemonMode")
 	notVerbose := fset.Bool("nv", false, "not log console")
 	newconfig := fset.Bool("newconfig", false, "not load existing config.json")
-	logLevel := fset.Int("loglevel", 1, "0:debug 1:info 2:warn 3:error")
+	logLevel := fset.Int("loglevel", gConf.LogLevel, "0:debug 1:info 2:warn 3:error")
 	maxLogSize := fset.Int("maxlogsize", 1024*1024, "default 1MB")
 	if cmd == "" {
 		if subCommand == "" { // no subcommand
@@ -490,7 +488,7 @@ func parseParams(subCommand string, cmd string) {
 	gConf.Network.UDPPort2 = UDPPort2
 	gLog.setLevel(LogLevel(gConf.LogLevel))
 	if *notVerbose {
-		gLog.setMode(LogFile)
+		gLog.setMode(gLog.Mode() &^ LogConsole)
 	}
 	// gConf.mtx.Unlock()
 	gConf.save()

--- a/core/log.go
+++ b/core/log.go
@@ -13,8 +13,8 @@ type LogLevel int
 var gLog *logger
 
 const (
-	LvDev   LogLevel = -1
-	LvDEBUG LogLevel = iota
+	LvDev LogLevel = iota + -1
+	LvDEBUG
 	LvINFO
 	LvWARN
 	LvERROR

--- a/core/log.go
+++ b/core/log.go
@@ -106,6 +106,11 @@ func (l *logger) setMode(mode int) {
 	defer l.mtx.Unlock()
 	l.mode = mode
 }
+func (l *logger) Mode() int {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	return l.mode
+}
 
 func (l *logger) checkFile() {
 	if l.maxLogSize <= 0 {


### PR DESCRIPTION
In log.go, I found that the update changed the values of the original LogLevels, increasing them by 1.
This is due to the fact that "iota" is incremented on every variable, regardless of whether the variable uses it or not.

![testing screenshot image](https://github.com/user-attachments/assets/f4733b2a-08ed-44b5-8d88-696b83af7084)

I fixed this at line 16 and did some extra changes shown in the commit message.
